### PR TITLE
👷 ci(circleci): update release workflow dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,9 +223,20 @@ workflows:
         - not: << pipeline.parameters.success-flag >>
         - not: << pipeline.parameters.validation-flag >>
     jobs:
+      - toolkit/save_next_version:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+
       - toolkit/make_release:
+          requires:
+            - toolkit/save_next_version
           context:
             - release
             - bot-check
           ssh_fingerprint: << pipeline.parameters.fingerprint >>
           min_rust_version: << pipeline.parameters.min-rust-version >>
+
+      - toolkit/no_release:
+          min_rust_version: << pipeline.parameters.min-rust-version >>
+          requires:
+            - toolkit/save_next_version:
+                - failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 🔧 chore(circleci): modify CircleCI configuration(pr [#75])
 - 👷 ci(circleci): update circleci toolkit orb version(pr [#76])
+- 👷 ci(circleci): update release workflow dependencies(pr [#77])
 
 ### Security
 
@@ -175,6 +176,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#74]: https://github.com/jerus-org/kdeets/pull/74
 [#75]: https://github.com/jerus-org/kdeets/pull/75
 [#76]: https://github.com/jerus-org/kdeets/pull/76
+[#77]: https://github.com/jerus-org/kdeets/pull/77
 [Unreleased]: https://github.com/jerus-org/kdeets/compare/v0.1.4...HEAD
 [0.1.4]: https://github.com/jerus-org/kdeets/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/jerus-org/kdeets/compare/v0.1.2...v0.1.3


### PR DESCRIPTION
- add save_next_version job to ensure version control before release
- modify make_release to depend on save_next_version for sequencing
- introduce no_release job for handling failed version save attempts