### PR TITLE
🔧 chore(config): simplify renovate configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - 🔧 chore(vscode)-update settings for SonarLint(pr [#126])
+- 🔧 chore(config)-simplify renovate configuration(pr [#127])
 
 ## [0.1.22] - 2025-06-28
 
@@ -370,6 +371,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#124]: https://github.com/jerus-org/kdeets/pull/124
 [#125]: https://github.com/jerus-org/kdeets/pull/125
 [#126]: https://github.com/jerus-org/kdeets/pull/126
+[#127]: https://github.com/jerus-org/kdeets/pull/127
 [Unreleased]: https://github.com/jerus-org/kdeets/compare/v0.1.22...HEAD
 [0.1.22]: https://github.com/jerus-org/kdeets/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/jerus-org/kdeets/compare/v0.1.20...v0.1.21

--- a/renovate.json
+++ b/renovate.json
@@ -1,79 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": true,
-  "rangeStrategy": "bump",
-  "prHourlyLimit": 0,
   "schedule": [
     "* 0-5 24 * *"
   ],
-  "hostRules": [
-    {
-      "matchHost": "circleci.com",
-      "authType": "Token-Only"
-    }
-  ],
-  "packageRules": [
-    {
-      "groupName": "futures packages",
-      "matchPackageNames": [
-        "/^futures[-_]?/"
-      ]
-    },
-    {
-      "groupName": "serde packages",
-      "matchPackageNames": [
-        "/^serde[-_]?/"
-      ]
-    },
-    {
-      "groupName": "tokio packages",
-      "matchPackageNames": [
-        "/^tokio[-_]?/"
-      ]
-    },
-    {
-      "groupName": "tracing packages",
-      "matchPackageNames": [
-        "/^tracing[-_]?/",
-        "!tracing-opentelemetry"
-      ]
-    },
-    {
-      "groupName": "liquid packages",
-      "matchPackageNames": [
-        "/^liquid[-_]?/",
-        "/^kstring$/"
-      ]
-    },
-    {
-      "automerge": true,
-      "matchPackageNames": [
-        "/github/codeql-action/",
-        "/ossf/scorecard-action/",
-        "/actions/upload-artifact/",
-        "/actions/checkout/"
-      ]
-    },
-    {
-      "sourceUrl": "https://github.com/jerus-org/circleci-toolkit",
-      "enabled": true,
-      "matchPackageNames": [
-        "/jerus-org/circleci-toolkit/"
-      ]
-    }
-  ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^rust-toolchain\\.toml?$"
-      ],
-      "matchStrings": [
-        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""
-      ],
-      "depNameTemplate": "rust",
-      "packageNameTemplate": "rust-lang/rust",
-      "datasourceTemplate": "github-releases"
-    }
+  "extends": [
+    "github>jerusdp/renovate-config:default.json"
   ]
 }


### PR DESCRIPTION
- remove detailed configuration settings for package grouping and custom managers
- extend from external shared configuration for consistency and maintenance ease