### PR TITLE
chore: update release.toml to reference PRLOG.md instead of CHANGELOG.md

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- chore-update release.toml to reference PRLOG.md instead of CHANGELOG.md(pr [#136])
+
+[#136]: https://github.com/jerus-org/kdeets/pull/136

--- a/release.toml
+++ b/release.toml
@@ -9,7 +9,7 @@ pre-release-replacements = [
     { file = "README.md", search = "kdeets 0.*", replace = "{{crate_name}} {{version}}" },
     { file = "tests/cmd/version.trycmd", search = "kdeets 0.*", replace = "{{crate_name}} {{version}}" },
     { file = "tests/cmd/version.trycmd", search = "kdeets-crate 0.*", replace = "{{crate_name}}-crate {{version}}" },
-    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
+    { file = "PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]


### PR DESCRIPTION
This PR updates the `release.toml` configuration file to reference `PRLOG.md` instead of `CHANGELOG.md`.

## Changes
- Updated all file references from `CHANGELOG.md` to `PRLOG.md` in `release.toml`
- No functional changes to the release process, only file name consistency

## Context
This change aligns with the recent standardization effort to use `PRLOG.md` (Pull Request Log) as the consistent naming convention for changelog files across all repositories. The release automation tooling now properly references the renamed changelog file.

## Files Modified
- `release.toml` - Updated file references in release configuration