### PR TITLE
fix: exclude test-reg from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["crates/kdeets"]
+exclude = ["test-reg"]
 resolver = "3"
 
 [workspace.package]


### PR DESCRIPTION
## Summary

- Adds `exclude = ["test-reg"]` to the workspace `Cargo.toml`
- `test-reg` is a test fixture crate — it should not be a workspace member
- Without this exclusion, Renovate fails to update `test-reg/Cargo.lock` because cargo sees the package as belonging to the workspace but not registered as a member

## Test plan
- [ ] CI passes
- [ ] Renovate can now update `test-reg/Cargo.lock` for the holochain_serialized_bytes_derive PR (#197)

🤖 Generated with [Claude Code](https://claude.com/claude-code)