### PR TITLE
refactor: use toolkit/code_coverage (nextest)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,94 +6,7 @@ parameters:
     default: "1.89"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
-  codecov: codecov/codecov@5.4.3
-
-jobs:
-  code_coverage:
-    description: >
-      Calculate code coverage and report summary in the terminal.
-      If flag set to true upload to codecov.io using the codecov orb.
-
-    executor:
-      name: toolkit/rust_env_rolling
-
-    parameters:
-      min_rust_version:
-        type: string
-        description: "Required: The minimum version of the rust compiler to use"
-      docker_tag_suffix:
-        type: string
-        default: ""
-        description: "The suffix to append to the docker tag"
-      codecov:
-        type: boolean
-        default: true
-        description: "If true, upload code coverage to codecov.io"
-      package:
-        type: string
-        default: ""
-        description: "The package to publish"
-      cache_version:
-        type: string
-        default: "v1"
-        description: "Cache version identifier"
-    steps:
-      - checkout
-
-      - restore_cache:
-          name: Restore dependency cache
-          keys:
-            - >
-              deps-<< parameters.cache_version >>-{{ arch }}-{{
-              checksum "Cargo.lock" }}
-            - deps-<< parameters.cache_version >>-{{ arch }}-
-
-      - restore_cache:
-          name: Restore build cache
-          keys:
-            - >
-              coverage-<< parameters.cache_version >>-{{ arch }}-{{
-              checksum "Cargo.lock" }}
-            - coverage-<< parameters.cache_version >>-{{ arch }}-
-      - run:
-          name: Code coverage
-          command: |
-            set -exo pipefail
-
-            if [ "<< parameters.package >>" != "" ] ; then
-              package="--package << parameters.package >>"
-            else
-              package=""
-            fi
-
-            mkdir -p coverage
-            cargo llvm-cov nextest --lcov --output-path coverage/lcov.info --all-features $package
-      - run:
-          name: Code Coverage Summary
-          command: |
-            cargo llvm-cov report --summary-only
-      - when:
-          condition: << parameters.codecov >>
-          steps:
-            - codecov/upload
-
-      - save_cache:
-          name: Save dependency cache
-          key: >
-            deps-<< parameters.cache_version >>-{{ arch }}-{{
-            checksum "Cargo.lock" }}
-          paths:
-            - ~/.cargo/registry
-            - ~/.cargo/git
-
-      - save_cache:
-          name: Save build cache
-          key: >
-            coverage-<< parameters.cache_version >>-{{ arch }}-{{
-            checksum "Cargo.lock" }}
-          paths:
-            - target
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   validation:
@@ -147,9 +60,9 @@ workflows:
             branches:
               ignore:
                 - /pull\/[0-9]+/
-      - code_coverage:
-          min_rust_version: << pipeline.parameters.min_rust_version >>
+      - toolkit/code_coverage:
           package: kdeets
+          test_runner: nextest
           filters:
             branches:
               ignore:

--- a/.circleci/release.yml
+++ b/.circleci/release.yml
@@ -23,7 +23,7 @@ parameters:
     description: "Override workspace v* version (empty = nextsv auto-detect)"
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 jobs:
   tools:

--- a/.circleci/update_prlog.yml
+++ b/.circleci/update_prlog.yml
@@ -15,7 +15,7 @@ parameters:
     description: "If true, pcu is updated from its main github branch before running."
 
 orbs:
-  toolkit: jerus-org/circleci-toolkit@6.2.0
+  toolkit: jerus-org/circleci-toolkit@6.3.0
 
 workflows:
   update_prlog:


### PR DESCRIPTION
## Summary

Migrates kdeets off its **local** `code_coverage` job onto the shared **`toolkit/code_coverage`**, enabled by toolkit 6.3.0's new optional `test_runner` parameter.

## Why

kdeets kept a local `code_coverage` copy solely because it runs coverage via `cargo llvm-cov nextest`, which the toolkit job didn't support. As a side effect it also carried its **own** `codecov/codecov@5.4.3` pin — a second codecov version to maintain, which broke independently during the org-wide Codecov uploader outage. toolkit 6.3.0 adds `test_runner: test|nextest` to `code_coverage`, so the local copy is no longer needed.

## Changes

- **Delete** the local `code_coverage` job (~85 lines).
- **Rewire** the workflow to `toolkit/code_coverage` with `package: kdeets`, `test_runner: nextest` — preserving the existing `cargo llvm-cov nextest` behaviour (no profile, matching the old job).
- **Remove** the `codecov/codecov@5.4.3` orb import — the toolkit owns the codecov orb version now (6.0.0 via 6.3.0).
- **Bump** `jerus-org/circleci-toolkit@6.2.0 → 6.3.0` across `config.yml`, `release.yml`, `update_prlog.yml`.

Net: `5 insertions(+), 92 deletions(-)`. Validated with `circleci config validate --org-slug gh/jerus-org` → valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)