### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,9 +335,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`RUSTSEC-2026-0204` (published 2026-07-06) landed in the RustSec DB, failing `cargo audit` here (transitive `crossbeam-epoch` 0.9.18 via rayon/moka).

**Fix:** `cargo update -p crossbeam-epoch` → **0.9.18 → 0.9.20** (advisory requires ≥0.9.20). Lockfile-only.

Verified: `cargo audit` clean, `cargo clippy --all --tests --all-features -D warnings` clean, `cargo fmt --all --check` clean, tests green.

Part of an org-wide sweep; future transitive advisories will be caught automatically once digital-prstv/renovate-config#74 (lockFileMaintenance) merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
